### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/transfer-accounts-manual.js
+++ b/transfer-accounts-manual.js
@@ -124,7 +124,15 @@ async function manualAccountTransfer() {
 manualAccountTransfer()
   .then(result => {
     console.log('\n=== TRANSFER RESULT ===');
-    console.log(JSON.stringify(result, null, 2));
+    // Sanitize sensitive fields before logging result
+    const redacted = { ...result };
+    if (redacted.to_account) {
+      redacted.to_account = '[REDACTED]';
+    }
+    if (redacted.from_account) {
+      redacted.from_account = '[REDACTED]';
+    }
+    console.log(JSON.stringify(redacted, null, 2));
     
     if (result.manual_steps_required) {
       console.log('\n📋 MANUAL STEPS REQUIRED:');


### PR DESCRIPTION
Potential fix for [https://github.com/thearbinaut05/click-clack-cash-flow/security/code-scanning/9](https://github.com/thearbinaut05/click-clack-cash-flow/security/code-scanning/9)

To fix the problem, we must prevent sensitive or confidential data—specifically values derived from environment variables—from being logged. In the current code, the `CORRECT_ACCOUNT_ID` (from `process.env.CONNECTED_ACCOUNT_ID`) is included in the object printed to the console (as `to_account`). The safest fix is to sanitize or redact this property when logging, while preserving all program behavior and without altering data flow for the remainder of the script. The best approach is to make a shallow clone of the result object before logging, and replace or redact any sensitive fields (e.g., set `to_account`, and potentially `from_account`, to a non-sensitive placeholder like `"[REDACTED]"` or output only the last few characters of the ID).

Edits needed:
- In the `.then` handler after `manualAccountTransfer()`, before logging `result`, create a shallow clone of `result`.
- Overwrite the `to_account` (and, if deemed sensitive, `from_account`) properties with a redacted value in this clone, if present.
- Log the sanitized clone.

No changes to imports or the rest of the program are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
